### PR TITLE
tests passing in 1.9.3, 2.0.0 and still passing in 2.1.0

### DIFF
--- a/lib/chassis/form.rb
+++ b/lib/chassis/form.rb
@@ -41,10 +41,10 @@ module Chassis
     end
 
     def included(base)
-      base.include Virtus.model
+      base.send(:include, Virtus.model)
       base.extend ClassMethods
-      base.include Virtus::DirtyAttribute
-      base.include InstanceMethods
+      base.send(:include, Virtus::DirtyAttribute)
+      base.send(:include, InstanceMethods)
     end
   end
 

--- a/lib/chassis/strategy.rb
+++ b/lib/chassis/strategy.rb
@@ -80,7 +80,7 @@ module Chassis
     end
 
     def included(base)
-      base.include DefaultImplementationsForInstances
+      base.send(:include, DefaultImplementationsForInstances)
     end
 
     def extended(klass)

--- a/test-multiple-rubies.sh
+++ b/test-multiple-rubies.sh
@@ -1,0 +1,14 @@
+
+echo "rbenv local 1.9.3-p484"A
+rbenv local 1.9.3-p484
+rake test
+echo "   "
+
+echo "rbenv local 2.0.0-p353" 
+rbenv local 2.0.0-p353
+rake test
+echo "   "
+
+echo "rbenv local 2.1.0-preview2"
+rbenv local 2.1.0-preview2
+rake test


### PR DESCRIPTION
Ran into trouble using repositories on 2.0.0.  Confirmed same on 1.9.3 and noted it was working on 2.1.0.

You will see that the fix is very straight forward and I have a feeling it is a bug in 2.1.0 that is allowing the use of include within a class level of execution.

Tried to track down some evidence of the 2.1.0 bug theory, best i could find that explains the expected behaviours:  http://stackoverflow.com/a/7296037

Original Exception:

```
% rake test
/Users/davetheninja/Work/oss/chassis-ah/lib/chassis/strategy.rb:83:in `included': private method `include' called for Chassis::Repo:Class (NoMethodError)
    from /Users/davetheninja/Work/oss/chassis-ah/lib/chassis/repo.rb:27:in `include'
    from /Users/davetheninja/Work/oss/chassis-ah/lib/chassis/repo.rb:27:in `<class:Repo>'
    from /Users/davetheninja/Work/oss/chassis-ah/lib/chassis/repo.rb:20:in `<module:Chassis>'
    from /Users/davetheninja/Work/oss/chassis-ah/lib/chassis/repo.rb:3:in `<top (required)>'
    from /Users/davetheninja/Work/oss/chassis-ah/lib/chassis.rb:63:in `require_relative'
    from /Users/davetheninja/Work/oss/chassis-ah/lib/chassis.rb:63:in `<top (required)>'
    from /Users/davetheninja/Work/oss/chassis-ah/test/test_helper.rb:4:in `require'
    from /Users/davetheninja/Work/oss/chassis-ah/test/test_helper.rb:4:in `<top (required)>'
    from /Users/davetheninja/Work/oss/chassis-ah/test/chassis_test.rb:1:in `require_relative'
    from /Users/davetheninja/Work/oss/chassis-ah/test/chassis_test.rb:1:in `<top (required)>'
    from /Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
    from /Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:9:in `each'
    from /Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:9:in `block in <main>'
    from /Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:4:in `select'
    from /Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -I"lib" -I"/Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rake-10.1.1/lib" "/Users/davetheninja/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rake-10.1.1/lib/rake/rake_test_loader.rb" "test/**/*_test.rb" ]

Tasks: TOP => test
(See full trace by running task with --trace)
```
