### PR TITLE
Feature: Return model in persistence

### DIFF
--- a/lib/chassis/persistence.rb
+++ b/lib/chassis/persistence.rb
@@ -32,6 +32,7 @@ module Chassis
     def save
       yield self if block_given?
       repo.save self
+      self
     end
 
     def delete

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -109,4 +109,12 @@ class PersistenceTest < MiniTest::Unit::TestCase
 
     assert_equal 6, model.id
   end
+
+  def test_save_returns_the_model
+    FakeRepo.expects(:save)
+
+    model = Model.new id: 5
+
+    assert_equal model, model.save
+  end
 end


### PR DESCRIPTION
Let the save method return the model to allow for cases like:

``` ruby
class SaveModel
  def initialize(model)
    @model = model
  end

  def call
    Model.save do |model|
      model.value = 'test'
    end
  end
end

use_case = SaveModel.new Model.new(id: 5)
model = use_case.call
```
