### PR TITLE
Remove intrusive middleware

### DIFF
--- a/lib/chassis/web_service.rb
+++ b/lib/chassis/web_service.rb
@@ -46,8 +46,6 @@ module Chassis
     use Rack::NoRobots
     use Rack::Bouncer
     use ::Rack::BounceFavicon
-    use ::Rack::Deflater
-    use Rack::JsonBodyParser
 
     set :cors, false
 

--- a/test/web_service_test.rb
+++ b/test/web_service_test.rb
@@ -51,10 +51,6 @@ class WebServiceTest < MiniTest::Unit::TestCase
     assert_error_message last_response, 'post'
   end
 
-  def test_parses_json_requests
-    assert_middleware app.middleware, Chassis::Rack::JsonBodyParser
-  end
-
   def test_blocks_robots
     assert_middleware app.middleware, Chassis::Rack::NoRobots
   end
@@ -65,10 +61,6 @@ class WebServiceTest < MiniTest::Unit::TestCase
 
   def test_blocks_noob_favicon
     assert_middleware app.middleware, Rack::BounceFavicon
-  end
-
-  def test_uses_gzip
-    assert_middleware app.middleware, Rack::Deflater
   end
 
   def test_can_enable_cors


### PR DESCRIPTION
Since there is no way to unload middleware. We shouldn't load intrusive
middleware such as gzip and json body parser. This is up to every
service/application using this code.
